### PR TITLE
Apptainer v1.1.6, golang 1.20.1.

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
         description: 'Apptainer version'
         type: choice
         required: true
-        default: 'v1.1.5'
+        default: 'v1.1.6'
         options:
           - 'main'
           - 'v1.1.0'
@@ -15,6 +15,7 @@ on:
           - 'v1.1.3'
           - 'v1.1.4'
           - 'v1.1.5'
+          - 'v1.1.6'
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.4-alpine3.17 as builder
+FROM golang:1.20.1-alpine3.17 as builder
 
 RUN apk add --no-cache \
         # Required for apptainer to find min go version
@@ -26,7 +26,7 @@ RUN git clone https://github.com/apptainer/apptainer.git \
     && make \
     && make install
 
-FROM alpine:3.17
+FROM alpine:3.17.2
 COPY --from=builder /usr/local/apptainer /usr/local/apptainer
 ENV PATH="/usr/local/apptainer/bin:$PATH" \
     APPTAINER_TMPDIR="/tmp-apptainer"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ INFO:    Downloading shub image
 
 ## Build image
 
-Apptainer version 1.1.5:
+Apptainer version 1.1.6:
 
 ```bash
-$ docker build --build-arg APPTAINER_COMMITISH=v1.1.5 -t apptainer:1.1.5 .
+$ docker build --build-arg APPTAINER_COMMITISH=v1.1.6 -t apptainer:1.1.6 .
 ```
 
 Bleeding-edge (main branch):


### PR DESCRIPTION
Apptainer released version 1.1.6.

For development: It might be efficient to somehow automatically get the latest Apptainer version and use it here instead of manually updating this repo.