### PR TITLE
Fix for latest Docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-alpine3.18 as builder
+FROM golang:1.23.3-alpine3.20 AS builder
 
 RUN apk add --no-cache \
         # Required for apptainer to find min go version
@@ -26,7 +26,7 @@ RUN git clone https://github.com/apptainer/apptainer.git \
     && make \
     && make install
 
-FROM alpine:3.18.2
+FROM alpine:3.20
 COPY --from=builder /usr/local/apptainer /usr/local/apptainer
 ENV PATH="/usr/local/apptainer/bin:$PATH" \
     APPTAINER_TMPDIR="/tmp-apptainer"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.23.3-alpine3.20 AS builder
 RUN apk add --no-cache \
         # Required for apptainer to find min go version
         bash \
+        binutils-gold \
         cryptsetup \
         gawk \
         gcc \


### PR DESCRIPTION
First, thanks for creating a great resource!

Due to a change in the minimum Docker API versions in later Docker versions, the image in this repository doesn't work anymore. This small PR should fix hopefully fix this and allow users with later Docker version to still utilise the image in this repository.